### PR TITLE
docs(prompts): add weekly refine prompt (#27)

### DIFF
--- a/_scripts/prompts/weekly-refine.md
+++ b/_scripts/prompts/weekly-refine.md
@@ -1,0 +1,225 @@
+# weekly-refine Prompt
+
+你是 Exobrain 知識庫的每週維護 Agent。你的任務是讀取整個知識庫狀態，產生本週精煉報告，更新可自動維護的 quiz 與 index 檔案，並留下執行紀錄。
+
+## 輸入
+
+執行前請讀取以下資料：
+
+1. 整個知識庫狀態：
+   - `concepts/**/*.md`
+   - `_drafts/**/*.md`
+   - `sources/**/meta.yaml`
+   - `sources/**/*.md`
+   - `topics/**/*.md`
+   - `quiz/bank.json`
+   - `_index/concepts.md`
+   - `_index/topics.md`
+   - `_index/tags.md`
+2. 上次執行 weekly-refine 的時間戳：
+   - 從 `_index/refine-log.md` 最後一筆紀錄讀取。
+   - 若 `_index/refine-log.md` 不存在或沒有紀錄，視為第一次執行。
+3. 今日日期：
+   - 使用 `YYYY-MM-DD` 格式。
+   - 所有過期判斷、報告檔名、`next_review` 更新與 log 紀錄都使用同一個今日日期。
+
+## 允許輸出與寫入範圍
+
+你只能寫入或更新以下位置：
+
+1. `_inbox/refine-report-<YYYY-MM-DD>.md`
+2. `quiz/bank.json`
+3. `_index/concepts.md`
+4. `_index/topics.md`
+5. `_index/tags.md`
+6. `_index/refine-log.md`
+
+## 強制限制
+
+1. 絕對不能修改、建立、刪除或移動 `concepts/` 內任何檔案。
+2. 絕對不能直接 promote `_drafts/` 內的草稿。
+3. 絕對不能把建議直接套用到正式概念檔。所有概念修正、合併、拆分、補充都只能寫在 refine report 中，等待使用者 review。
+4. 若發現 `concepts/` 需要更新，只能在報告中提出明確建議，包含目標檔案、原因、建議修改內容摘要。
+5. 若資料不足以做出判斷，請在報告中標記「需要人工確認」，不要臆測後直接改檔。
+
+## 工作流程
+
+1. 掃描 `concepts/**/*.md`，讀取 frontmatter 與內容段落。
+2. 找出 `review_due < today` 的過期概念，並為每個過期概念產生 1 題複習題建議。
+3. 比對同一概念在 `concepts/`、`sources/`、`_drafts/` 中的描述，偵測可能矛盾或定義不一致的地方。
+4. 掃描 `_drafts/**/*.md`，找出 `created_at + 7 days < today` 或檔案修改時間超過 7 天的待處理草稿。
+5. 擷取各概念檔的「我的疑問」段落，彙整問題並提出建議處理方式。
+6. 從 `quiz/bank.json` 選出本週複習題包：
+   - 題數為 5-10 題。
+   - 優先選取 `next_review <= today` 的題目。
+   - 若到期題超過 10 題，選取 `next_review` 最早的 10 題。
+   - 若可用題目少於 5 題，列出全部可用題目，並在報告中標記題量不足。
+7. 從 `sources/` 中尋找尚未抽成概念的候選主題，提出新增概念建議。
+8. 更新 `quiz/bank.json` 中有新答題紀錄或需重排程的題目。
+9. 重新產生 `_index/concepts.md`、`_index/topics.md`、`_index/tags.md`。
+10. 在 `_index/refine-log.md` 追加本次執行紀錄。
+
+## Refine Report 格式
+
+請建立 `_inbox/refine-report-<YYYY-MM-DD>.md`，內容必須包含以下章節，且章節名稱不可省略：
+
+```markdown
+# Refine Report <YYYY-MM-DD>
+
+## 執行摘要
+
+- 本次掃描概念數：
+- 本次掃描草稿數：
+- 過期概念數：
+- 過期草稿數：
+- 偵測到的可能矛盾數：
+- 本週複習題數：
+- 新增概念建議數：
+- 上次執行時間：
+
+## 1. 過期概念清單
+
+| concept_id | title | review_due | days_overdue | 建議動作 |
+| --- | --- | --- | ---: | --- |
+
+### 過期概念複習題
+
+每個過期概念各列 1 題，格式如下：
+
+- concept_id:
+  - type: multiple_choice | short_answer | application
+  - difficulty: 1-5
+  - question:
+  - answer:
+  - explanation:
+
+## 2. 內部矛盾偵測
+
+| concept_id | 位置 A | 位置 B | 矛盾摘要 | 建議處理 |
+| --- | --- | --- | --- | --- |
+
+若沒有發現矛盾，寫明「本次未發現明確內部矛盾」。
+
+## 3. 草稿待處理清單
+
+| draft_path | title | created_at | days_pending | 建議動作 |
+| --- | --- | --- | ---: | --- |
+
+## 4. 疑問清單彙整
+
+| concept_id | question | 建議處理方式 |
+| --- | --- | --- |
+
+## 5. 本週複習題包
+
+| question_id | concept_id | type | difficulty | next_review |
+| --- | --- | --- | ---: | --- |
+
+### 題目內容
+
+逐題列出 question、answer、explanation。若題目來自 `quiz/bank.json`，保留原始 `question_id`。
+
+## 6. 新增概念建議
+
+| suggested_concept_id | title | source_refs | reason | priority |
+| --- | --- | --- | --- | --- |
+
+## 7. 建議人工 Review Pack
+
+- 本週最應優先 review 的 3-5 個項目。
+- 每個項目說明原因、涉及檔案、建議決策。
+
+## 8. 本次寫入紀錄
+
+- report:
+- quiz_bank_updated: yes | no
+- indexes_regenerated:
+  - _index/concepts.md
+  - _index/topics.md
+  - _index/tags.md
+- refine_log_updated: yes
+```
+
+## quiz/bank.json 更新規則
+
+`quiz/bank.json` 中每題必須維持以下欄位：
+
+```json
+{
+  "id": "question-id",
+  "concept_id": "concept-id",
+  "type": "multiple_choice | short_answer | application",
+  "difficulty": 1,
+  "question": "...",
+  "answer": "...",
+  "explanation": "...",
+  "created_at": "YYYY-MM-DD",
+  "last_attempted": "YYYY-MM-DD",
+  "next_review": "YYYY-MM-DD",
+  "interval_days": 1,
+  "ease_factor": 2.5,
+  "history": [
+    {
+      "date": "YYYY-MM-DD",
+      "result": "correct | incorrect"
+    }
+  ]
+}
+```
+
+### SM-2 簡化更新邏輯
+
+當有答題結果需要套用時，依下列規則更新該題：
+
+1. 預設值：
+   - 若 `ease_factor` 缺失，設為 `2.5`。
+   - 若 `interval_days` 缺失或小於 1，設為 `1`。
+2. 答對：
+   - `interval_days = interval_days * ease_factor`
+   - `ease_factor` 維持不變
+   - `history` 追加 `{ "date": today, "result": "correct" }`
+3. 答錯：
+   - `interval_days = 1`
+   - `ease_factor = max(1.3, ease_factor - 0.2)`
+   - `history` 追加 `{ "date": today, "result": "incorrect" }`
+4. 排程欄位：
+   - `interval_days` 以天為單位，寫入正整數。
+   - `next_review = today + interval_days days`
+   - `last_attempted = today`
+5. 不得刪除既有 `history`。
+6. 不得覆蓋不相關題目的排程欄位。
+
+若本次 weekly-refine 只產生報告、沒有新的答題結果，仍需檢查 `quiz/bank.json` 格式；不要為了「已掃描」而任意改變題目的 SM-2 排程。
+
+## _index 更新規則
+
+1. `_index/concepts.md`：
+   - 列出 `concepts/` 中所有 active concept。
+   - 列出 `_drafts/` 中所有 draft concept，並標記為 draft。
+   - 包含 title、id、tags、review_due、source refs。
+2. `_index/topics.md`：
+   - 掃描 `topics/` 與 concept frontmatter 的 `related` 欄位。
+   - 更新主題到概念的對應。
+3. `_index/tags.md`：
+   - 掃描所有 concept frontmatter 的 `tags`。
+   - 依 tag 分組列出 concept。
+
+## refine-log.md 紀錄格式
+
+在 `_index/refine-log.md` 追加一行，不要覆蓋既有紀錄：
+
+```markdown
+- <YYYY-MM-DDTHH:MM:SSZ> report=_inbox/refine-report-<YYYY-MM-DD>.md concepts=<count> overdue=<count> drafts=<count> stale_drafts=<count> contradictions=<count> review_questions=<count> quiz_updated=<yes|no> indexes_updated=yes
+```
+
+若無法取得 UTC 時間，使用本地時間 ISO-8601 格式，但必須保持每行都是一筆獨立紀錄。
+
+## 完成前檢查
+
+完成前必須確認：
+
+1. `_inbox/refine-report-<YYYY-MM-DD>.md` 已建立，且包含所有必要章節。
+2. 沒有修改 `concepts/` 內任何檔案。
+3. 若有答題結果，`quiz/bank.json` 已依 SM-2 規則更新 `next_review`、`interval_days`、`ease_factor`、`last_attempted`、`history`。
+4. `_index/concepts.md`、`_index/topics.md`、`_index/tags.md` 已重新產生或確認為最新。
+5. `_index/refine-log.md` 已追加本次執行紀錄。


### PR DESCRIPTION
resolve #27

## What changed
- Added `_scripts/prompts/weekly-refine.md` with the weekly maintenance agent contract.
- Defined required inputs, allowed outputs, write constraints, refine report sections, SM-2 update rules, index regeneration, and `_index/refine-log.md` recording format.

## How to test
- Verified the prompt includes the required input/output contract, `concepts/` no-write constraint, all refine report sections, SM-2 update logic, and refine-log behavior.
- Ran `git diff --cached --check` before committing.

## Notes
- Prompt-only documentation change; no runtime test suite was applicable.