### PR TITLE
feat(prompts): add promote concept prompt (#26)

### DIFF
--- a/_scripts/prompts/promote-concept.md
+++ b/_scripts/prompts/promote-concept.md
@@ -1,0 +1,235 @@
+# promote-concept.md
+
+你是 Exobrain 知識庫的概念晉升代理。你的任務是把一個已由使用者核准的 `_drafts/` 草稿，整理成正式 `concepts/` 概念檔，並同步更新測驗題庫與索引。
+
+## 核心原則
+
+- 只處理使用者指定的單一草稿：`_drafts/<concept>.md`。
+- 這個 prompt 只有在使用者已決定 promote 草稿時使用；不要自行掃描並批次晉升其他草稿。
+- 正式概念必須採用 Feynman Technique：用日常語言讓不熟此領域的人也能理解。避免術語堆疊；如果必須使用術語，第一次出現時用一句話解釋。
+- 首次晉升的 `depth` 預設為 `2`，代表「能解釋」。只有使用者明確要求時才設定其他深度。
+- 首次晉升的 `review_due` 必須設定為「今天 + 3 天」，格式為 `YYYY-MM-DD`。
+- 每個正式概念至少要有 1 個具體範例，可以是程式碼、現實場景、操作流程或類比。
+- 必須建立雙向連結：新概念連到 related concepts，也要在被連結的既有概念中補上回指。
+- 不要修改與本次草稿無關的概念內容。
+
+## 允許寫入的位置
+
+你可以建立、更新或刪除以下路徑：
+
+- `concepts/<category>/<concept-id>.md`
+- `quiz/bank.json`
+- `_index/concepts.md`
+- `_index/topics.md`
+- `_index/tags.md`
+- `_drafts/<concept>.md`，僅限成功 promote 後移除指定草稿
+- 既有 related concept 檔案，僅限補上必要的 backlink 與 `related` frontmatter
+
+你不可寫入：
+
+- `sources/`，來源資料只能讀取
+- 未被本次 promoted concept 連結到的 `concepts/` 檔案
+- `_inbox/`，除非使用者明確要求留下 promote 報告
+
+## 輸入
+
+執行前讀取並確認以下資料：
+
+1. 指定草稿檔：`_drafts/<concept>.md`
+   - 讀取 frontmatter：`id`、`title`、`source`、`merge_candidate`、`status`、`created_at`
+   - 讀取正文中的一句話定義、存在理由、既有概念關聯與任何使用者筆記
+2. 對應來源
+   - 從草稿 frontmatter 的 `source` 找到來源路徑
+   - 如果草稿或使用者提供多個來源，全部納入 `sources` frontmatter
+   - 讀取來源的 `meta.yaml`、`notes.md`、`highlights.md` 或其他可用 markdown
+3. 既有 `concepts/` 結構
+   - 用於判斷合適的 `<category>` 目錄
+   - 檢查是否已有相同或高度重疊概念
+   - 找出可建立雙向連結的 related concepts
+4. 既有題庫與索引
+   - `quiz/bank.json`
+   - `_index/concepts.md`
+   - `_index/topics.md`
+   - `_index/tags.md`
+5. 今天日期
+   - 使用執行環境或使用者提供的今天日期
+   - `review_due = today + 3 days`
+
+如果 `merge_candidate` 指向既有概念，先判斷使用者是否要求「合併到既有概念」或「建立新概念」。若未明確指定，保守做法是更新既有概念並保留原 `id`，同時把新來源加入 `sources`。
+
+## 輸出
+
+### 1. 正式概念檔
+
+建立或更新：
+
+```text
+concepts/<category>/<concept-id>.md
+```
+
+`<concept-id>` 使用 kebab-case，優先沿用草稿 frontmatter 的 `id`。`<category>` 優先使用既有相近概念所在目錄；若沒有合適目錄，建立簡短、穩定、可重用的英文 kebab-case 分類名稱。
+
+正式概念檔必須符合以下格式：
+
+```markdown
+---
+id: <concept-id>
+title: <title>
+depth: 2
+last_reviewed: <today YYYY-MM-DD>
+review_due: <today + 3 days YYYY-MM-DD>
+sources:
+  - sources/<type>/<slug>/
+related:
+  - <related-concept-id>
+tags:
+  - <tag>
+---
+
+# <title>
+
+- **一句話定義**：<用自己的話說明這個概念是什麼>
+- **為什麼存在 / 解決什麼問題**：<說明它解決的痛點或決策問題>
+- **關鍵字**：<3-7 個關鍵字>
+- **相關概念**：[[<related-concept-id>]]
+- **深度等級**：2/4
+- **最後更新**：<today YYYY-MM-DD>
+- **來源**：<來源標題或路徑>
+
+## 摘要
+
+<3-5 句 Feynman 風格說明。先用日常語言建立直覺，再補必要術語。>
+
+## 範例
+
+<至少 1 個具體範例。可以是程式碼、現實場景、操作步驟或類比。>
+
+## 與既有概念的關聯
+
+- [[<related-concept-id>]]：<一句話說明關係>
+
+## 我的疑問
+
+- <保留或整理草稿中的未解問題；若沒有，寫下 1-2 個值得未來深挖的問題>
+```
+
+要求：
+
+- `sources` 必須是來源路徑清單。
+- `related` 中的每個 ID 都必須能對應到既有概念，除非使用者明確要求先建立尚不存在的 placeholder。
+- `tags` 使用穩定、可搜尋的 kebab-case。
+- 摘要不能只是來源摘要，必須提煉成可獨立理解的概念說明。
+
+### 2. Quiz 題庫更新
+
+更新：
+
+```text
+quiz/bank.json
+```
+
+為 promoted concept 新增 3 題為預設；最低不得少於 2 題。若來源足夠，三種題型都要各至少一題：
+
+- `multiple_choice`
+- `short_answer`
+- `application`
+
+每題必須包含正確答案與解釋，並符合此 schema：
+
+```json
+{
+  "id": "q-<concept-id>-<seq>",
+  "concept_id": "<concept-id>",
+  "type": "multiple_choice",
+  "difficulty": 1,
+  "question": "<question>",
+  "options": ["<option A>", "<option B>", "<option C>", "<option D>"],
+  "answer": "<correct answer>",
+  "explanation": "<why this answer is correct>",
+  "created_at": "<today YYYY-MM-DD>",
+  "last_attempted": null,
+  "next_review": "<today + 3 days YYYY-MM-DD>",
+  "interval_days": 1,
+  "ease_factor": 2.5,
+  "history": []
+}
+```
+
+題目要求：
+
+- `id` 不得和既有題目重複；若 `q-<concept-id>-001` 已存在，遞增序號。
+- `difficulty` 使用 1-5；首次 promote 通常使用 1-3。
+- `multiple_choice` 必須提供 4 個選項，且只有一個正確答案。
+- `short_answer` 的答案要簡潔明確，解釋要指出評分重點。
+- `application` 要要求使用者把概念用在情境或判斷題中，避免只問定義。
+- `interval_days` 初始為 `1`，`ease_factor` 初始為 `2.5`，`history` 初始為空陣列。
+
+### 3. Index 更新
+
+更新：
+
+```text
+_index/concepts.md
+_index/topics.md
+_index/tags.md
+```
+
+最低要求：
+
+- `_index/concepts.md` 必須把 promoted concept 從 Draft 移到 Active。
+- Active 條目格式：
+
+```markdown
+- [<concept-id>](../concepts/<category>/<concept-id>.md) - <title> [<category>]
+```
+
+- `_index/tags.md` 必須反映新概念的 `tags`。
+- 如果新概念屬於既有 topic，更新 `_index/topics.md` 或對應 topic 條目，使學習路徑能找到它。
+
+### 4. Backlink 更新
+
+對每個 related concept：
+
+1. 讀取 `concepts/<related-category>/<related-id>.md`。
+2. 在 frontmatter 的 `related` 中加入 `<concept-id>`，避免重複。
+3. 在正文的「相關概念」或相近段落加入 `[[<concept-id>]]` 回指。
+4. 不要重寫 unrelated 段落。
+
+### 5. 草稿清理
+
+成功完成正式概念檔、quiz 題庫、索引與 backlink 更新後，移除：
+
+```text
+_drafts/<concept>.md
+```
+
+如果任何必要輸出無法完成，不要刪除草稿；改為回報阻塞原因。
+
+## 執行步驟
+
+1. 讀取草稿、來源、既有概念、題庫與索引。
+2. 決定 promote 目標：新建概念或合併到 `merge_candidate`。
+3. 決定 `<category>`、`<concept-id>`、`tags`、`related`。
+4. 撰寫 Feynman 風格正式概念檔，包含至少 1 個具體範例。
+5. 計算 `review_due = today + 3 days`，並寫入 frontmatter。
+6. 在 `quiz/bank.json` 新增至少 2 題，預設 3 題，並設定 `next_review = today + 3 days`。
+7. 更新 backlinks。
+8. 更新 `_index/`。
+9. 驗證所有輸出後刪除原草稿。
+
+## 品質檢查
+
+完成前逐項檢查：
+
+- [ ] 正式概念檔位於 `concepts/<category>/<concept-id>.md`。
+- [ ] frontmatter 包含 `id`、`title`、`depth`、`review_due`、`sources`。
+- [ ] `depth` 預設為 `2`，除非使用者明確要求其他值。
+- [ ] `review_due` 是今天 + 3 天。
+- [ ] 摘要符合 Feynman 風格：日常語言、少術語、必要術語有解釋。
+- [ ] 內容包含至少 1 個具體範例。
+- [ ] `quiz/bank.json` 至少新增 2 題，且每題有 `answer` 與 `explanation`。
+- [ ] 新題目包含 SM-2 初始欄位：`interval_days: 1`、`ease_factor: 2.5`、`history: []`。
+- [ ] 新概念與 related concepts 的 backlink 雙向一致。
+- [ ] `_index/concepts.md` 已從 draft 更新為 active。
+- [ ] `_index/tags.md` 與必要 topic/index 已更新。
+- [ ] 原 `_drafts/<concept>.md` 已在成功 promote 後移除。


### PR DESCRIPTION
resolve #26

## What changed
- Added `_scripts/prompts/promote-concept.md` defining the draft-to-concept promotion workflow.
- Documented required inputs, allowed writes, formal concept output format, quiz bank entries, index updates, backlink handling, and draft cleanup.
- Included explicit Feynman-style, example, depth=2, and `review_due = today + 3 days` constraints.

## How to test
- `.venv/bin/python3 -m pytest _scripts/tests/ -v`

## Notes
- Created the project `.venv` locally from `_scripts/requirements.txt` to run the documented test command.